### PR TITLE
fix: skip `native_unwind_info(false)` on Windows

### DIFF
--- a/crates/isola/src/internal/module/configure.rs
+++ b/crates/isola/src/internal/module/configure.rs
@@ -6,6 +6,8 @@ pub fn configure_engine(cfg: &mut Config) {
     cfg.table_lazy_init(false);
     cfg.generate_address_map(false);
     cfg.wasm_backtrace_max_frames(None);
+    // Wasmtime rejects `native_unwind_info(false)` on Windows (ABI requires unwind info).
+    #[cfg(not(target_os = "windows"))]
     cfg.native_unwind_info(false);
     cfg.cranelift_opt_level(wasmtime::OptLevel::Speed);
 }


### PR DESCRIPTION
Address #178 

Disable `native_unwind_info(false)` on Windows